### PR TITLE
問題番号、解答、正答の読み取り結果を表示

### DIFF
--- a/final.py
+++ b/final.py
@@ -2,7 +2,8 @@ import os
 from flask import Flask, request, redirect, url_for, render_template, flash
 from werkzeug.utils import secure_filename
 from keras.models import Sequential, load_model
-from keras.preprocessing import image
+# from keras.preprocessing import image
+import keras.preprocessing.image
 #from tensorflow.keras.initializers import GlorotUniform
 import tensorflow as tf
 import numpy as np
@@ -11,9 +12,10 @@ import matplotlib.pyplot as plt
 import pyzbar.pyzbar as pyzbar
 from pyzbar.pyzbar import decode
 from PIL import Image, ImageDraw, ImageFont
+from keras_preprocessing import image
 
 #model = load_model('auto_scoring/model.h5')#学習済みモデルをロードする
-model = tf.keras.models.load_model('model.h5')#学習済みモデルをロードする
+model = tf.keras.models.load_model('model_mnist.h5')#学習済みモデルをロードする
 
 app = Flask(__name__)
 
@@ -52,9 +54,11 @@ def upload_file():
             img_file.save(os.path.join(UPLOAD_FOLDER,img_filename))
             img_filepath = os.path.join(UPLOAD_FOLDER, img_filename)
             
-            qr_img = image.load_img(img_filepath ,grayscale=True,target_size=(image_size,image_size))
-            gray_img = cv2.cvtColor(qr_img, cv2.COLOR_BGR2GRAY)
-            blurred_img = cv2.GaussianBlur(gray_img, (11,11),0)
+            # qr_img = keras.preprocessing.image.load_img(img_filepath ,grayscale=True,target_size=(image_size,image_size))
+            qr_imgcv = cv2.imread(img_filepath)
+            # gray_img = cv2.cvtColor(qr_img, cv2.COLOR_BGR2GRAY)
+            gray_imgcv = cv2.cvtColor(qr_imgcv, cv2.COLOR_BGR2GRAY)
+            blurred_img = cv2.GaussianBlur(gray_imgcv, (11,11),0)
             barcodes = pyzbar.decode(blurred_img)
             
     
@@ -62,13 +66,13 @@ def upload_file():
             i=1
 
             ans_correct  = 0
-
+            qr_list = np.empty((1,3))
             for  barcode in barcodes:
                 (x, y, w, h) = barcode.rect
                 #以下imwriteは確認
                 #binary image 
                 barcodeData = barcode.data.decode("utf-8")
-                crop_cut = gray_img[y:y+h ,x+310 :x+w+310]
+                crop_cut = gray_imgcv[y:y+h ,x+310 :x+w+310]
                 th, binary = cv2.threshold(crop_cut,125, 255, cv2.THRESH_BINARY)
                 #cv2.imwrite('crop_cut_binary_{}.jpg'.format(i),binary)
 
@@ -78,7 +82,7 @@ def upload_file():
 
                 
                 _, thresh = cv2.threshold(binary, 125, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
-                image, contours, hierarchy = cv2.findContours(thresh, 3, cv2.CHAIN_APPROX_NONE)
+                contours, hierarchy = cv2.findContours(thresh, 3, cv2.CHAIN_APPROX_NONE)
                 cnt = contours[0]
                 X, Y, W, H = cv2.boundingRect(cnt) 
                 rectangle = binary2black[Y:Y+H,X:X+W]
@@ -105,15 +109,20 @@ def upload_file():
                     ans_correct += 1
                 else:
                     print('The answer is incorrect')
-
+                qr_list = np.append(qr_list, [[qr_que, qr_ans, true_ans]], axis=0)
         
+        qr_list = np.delete(qr_list, 0, 0)
+        qr_list = qr_list[qr_list[:,0].argsort(), :]
         x1 = (ans_correct / 10.0) * 100
         print('If the prediction is 100% correct. The correct rate of answer is {} %'.format(x1))
-                        
+        return render_template('result.html', res_list=qr_list)                
     #img_read = cv2.imread('test2.jpg')
     #read_pred(img_read)
+    return render_template('index.html', answer = '')
 
-
+#直接実行した時のみに動く
+if __name__ == '__main__':
+    app.run(port=8000, debug=True)
 
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<title>解答自動採点</title>
+<head>
+    <title>解答自動採点くん</title>
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+            integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+            crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"
+            integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
+            crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+            integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+            crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
+          integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" type=text/css href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+
+<header>
+    <div class="navbar navbar-dark bg-dark box-shadow">
+        <div class="container d-flex justify-content-between">
+            <a href="/" class="navbar-brand d-flex align-items-center">
+                <strong>解答自動採点くん</strong>
+            </a>
+        </div>
+    </div>
+</header>
+
+<div class="container">
+    {% block body %}
+    {% endblock %}
+</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,3 +1,5 @@
+{% extends "base.html" %}
+{% block body %}
 <!DOCTYPE html>
 <html lang="ja">
 <head>
@@ -14,15 +16,12 @@
     </header>
 
     <div class="main">    
-        <h2> 送信された画像の数字を識別します</h2>
+        <h2>解答用紙画像をアップロードしてください。</h2>
         <form method="POST" enctype="multipart/form-data">
             <p>未記入の解答欄画像を送信してください</p>
-            <input class="file_choose" type="file" name="qr_file" id='qr_file'>
-            <p>記入済み解答欄画像を送信してください</p>
-            <input class="file_choose" type="file" name="ans_file" id='ans_file'>
-            <input class="btn" value="submit!" type="submit">
+            <input class="file_choose" type="file" name="img_file" id='img_file'>
+            <input class="btn" value="送信" type="submit">
         </form>
-        <div class="answer">{{answer}}</div>
     </div>
 
     <footer>
@@ -31,3 +30,4 @@
 </body>
 </html>
 
+{% endblock %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,8 +1,25 @@
+{% extends "base.html" %}
+{% block body %}
 <!DOCTYPE html>
 <title>QR ANSWER App</title>
-{% if answer %}
-  <h1>{{answer}}</h1>
-  <a href="./">トップへ戻る</a>
+{% if res_list.any() %}
+  <table class="table">
+    <tr>
+      <th>問題番号</th>
+      <th>答案</th>
+      <th>正答</th>
+    </tr>
+    {% for result in res_list %}
+    <tr>
+      <td>{{result[0]}}</td>
+      <td>{{result[1]}}</td>
+      <td>{{result[2]}}</td>
+    </tr>
+    {% endfor %}
+  </table>
+  <a href="./">トップへ</a>
 {% else %}
-  <a href="./">トップへ戻る</a>
+  <a href="./">戻る</a>
 {% endif %}
+
+{% endblock %}


### PR DESCRIPTION
final.pyは画像の扱いをcvへ変更
画像を読み取った順に配列に追加されたので、後でソートして表示した。

Bootstrapさまさま

-----

変更内容
入力画像：
![test3](https://user-images.githubusercontent.com/38688998/70850983-87976480-1ed3-11ea-8a79-5e99123dadf2.jpg)


出力結果：
<img width="676" alt="キャプチャ" src="https://user-images.githubusercontent.com/38688998/70850974-76e6ee80-1ed3-11ea-80a8-f6d9a3b2e8d4.PNG">
